### PR TITLE
fix attr_ indexing naming

### DIFF
--- a/src/main/java/org/lareferencia/core/metadata/MDTransformerParameterSetter.java
+++ b/src/main/java/org/lareferencia/core/metadata/MDTransformerParameterSetter.java
@@ -82,7 +82,7 @@ public class MDTransformerParameterSetter {
 	
 					if ( valueOfResult != null ) { // if value is not null
 						// set the parameter using the prefixed name of field and the string value of the field 
-						String fieldName = parameterNamePrefix + name.substring(3).toLowerCase(); 
+						String fieldName = parameterNamePrefix + name.toLowerCase(); 
 						if (valueOfResult instanceof List) {
 							List<String> items = (List<String>) valueOfResult; 
 							transformer.setParameter(fieldName, items);


### PR DESCRIPTION
Currently `name.substring(3)` is truncating field name. For instance: field email instead of `attr_email` is becoming `attr_il`. This PR fixes this.