### PR TITLE
Improve embedding generation by chunking abstracts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 			<version>5.0.0-beta</version>
 		</dependency>
 
-		
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
@@ -75,7 +75,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webflux</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>dev.langchain4j</groupId>
+			<artifactId>langchain4j-spring-boot-starter</artifactId>
+			<version>1.15.0-beta25</version>
+		</dependency>
 
 
 		<dependency>
@@ -95,17 +99,17 @@
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-		
+
 		<dependency>
-		    <groupId>com.h2database</groupId>
-		    <artifactId>h2</artifactId>
-		    <version>2.1.214</version>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<version>2.1.214</version>
 		</dependency>
-		
+
 		<dependency>
-		    <groupId>org.xerial</groupId>
-		    <artifactId>sqlite-jdbc</artifactId>
-		    <version>3.42.0.0</version>
+			<groupId>org.xerial</groupId>
+			<artifactId>sqlite-jdbc</artifactId>
+			<version>3.42.0.0</version>
 		</dependency>
 
 		<dependency>
@@ -113,7 +117,7 @@
 			<artifactId>hibernate-community-dialects</artifactId>
 		</dependency>
 
-		
+
 
 		<!-- Tika -->
 
@@ -124,14 +128,14 @@
 		</dependency>
 
 		<!-- ADDED: Missing dependencies for Spring Boot 3.x -->
-		
+
 		<!-- JSON Simple for JWT parsing -->
 		<dependency>
 			<groupId>com.googlecode.json-simple</groupId>
 			<artifactId>json-simple</artifactId>
 			<version>1.1.1</version>
 		</dependency>
-		
+
 		<!-- Joda Time for date/time handling (legacy code) -->
 		<dependency>
 			<groupId>joda-time</groupId>
@@ -181,14 +185,14 @@
 		</dependency>
 
 		<dependency>
-  			<groupId>com.github.ben-manes.caffeine</groupId>
-  			<artifactId>caffeine</artifactId>
-  			<version>3.0.5</version>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+			<version>3.0.5</version>
 		</dependency>
 
 		<!-- Flowable BPMN Process Engine (Manual Configuration) -->
 		<!-- Using individual dependencies instead of Spring Boot starter for full control -->
-		
+
 		<!-- Flowable Core Engine -->
 		<dependency>
 			<groupId>org.flowable</groupId>

--- a/src/main/java/org/lareferencia/core/embedding/EmbeddingService.java
+++ b/src/main/java/org/lareferencia/core/embedding/EmbeddingService.java
@@ -1,0 +1,91 @@
+package org.lareferencia.core.embedding;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.lareferencia.core.embedding.client.EmbeddingAPIClient;
+import org.lareferencia.core.embedding.client.EmbeddingData;
+import org.lareferencia.core.embedding.client.EmbeddingRequest;
+import org.lareferencia.core.embedding.client.EmbeddingResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmbeddingService implements IEmbeddingService {
+
+  private static Logger logger = LogManager.getLogger(EmbeddingService.class);
+  @Autowired
+  private EmbeddingAPIClient embeddingAPIClient;
+  @Value("${embedding.model.name}")
+  private String embeddingModelName;
+  @Value("${embedding.model.datatype}")
+  private String embeddingModelDataType;
+  @Value("${embedding.model.dimension}")
+  private int embeddingModelDimension;
+  @Value("${embedding.model.applicationId}")
+  private String embeddingApplicationId;
+
+  @Override
+  public Optional<List<Float>> embed(String text) {
+    return callEmbeddingAPI(text)
+        .filter(list -> !list.isEmpty())
+        .map(list -> list.get(0));
+  }
+
+  @Override
+  public Optional<List<List<Float>>> embed(List<String> texts) {
+    logger.info(MessageFormat.format("Count of texts for embeddings: {0}", texts.size()));
+    return callEmbeddingAPI(texts);
+  }
+
+  @Override
+  public int getEmbeddingDimension() {
+    return embeddingModelDimension;
+  }
+
+  private Optional<List<List<Float>>> callEmbeddingAPI(Object textForEmbedding) {
+    try {
+      EmbeddingResponse response = embeddingAPIClient.generateEmbedding(
+          new EmbeddingRequest(textForEmbedding,
+              embeddingModelName,
+              embeddingModelDataType,
+              embeddingModelDimension,
+              embeddingApplicationId));
+
+      if (response != null && response.getData() != null && !response.getData().isEmpty()) {
+
+        List<List<Float>> embeddings = response.getData()
+            .stream()
+            .map(EmbeddingData::getEmbedding)
+            .toList();
+
+        if (embeddings == null || embeddings.isEmpty()) {
+          logger.warn(MessageFormat.format("Embedding API returned empty vector for text: {0}", textForEmbedding));
+          return Optional.empty();
+        }
+
+        logger.info(MessageFormat.format("Count of vectors: {0}", embeddings.size()));
+
+        var  vectorsDimension = embeddings.get(0).size();
+
+        if (vectorsDimension != embeddingModelDimension) {
+          logger.warn(MessageFormat.format(
+              "Embedding dimension mismatch: expected {0}, got {1}.", embeddingModelDimension, vectorsDimension));
+          return Optional.empty();
+        }
+
+        return Optional.of(embeddings);
+      }
+    } catch (Exception e) {
+      logger.error(MessageFormat.format("Failed to generate embedding | Error: {0}", e.getMessage()));
+
+    }
+
+    return Optional.empty();
+  }
+
+}

--- a/src/main/java/org/lareferencia/core/embedding/EmbeddingService.java
+++ b/src/main/java/org/lareferencia/core/embedding/EmbeddingService.java
@@ -1,3 +1,23 @@
+/*
+ *   Copyright (c) 2013-2026. LA Referencia / Red CLARA and others
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   This file is part of LA Referencia software platform LRHarvester v5.x
+ *   For any further information please contact Lautaro Matas <lmatas@gmail.com>
+ */
+
 package org.lareferencia.core.embedding;
 
 import java.text.MessageFormat;
@@ -14,6 +34,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+/**
+ * Default {@link IEmbeddingService} implementation backed by
+ * {@link EmbeddingAPIClient}.
+ *
+ * <p>
+ * This service encapsulates request construction, basic response validation,
+ * and dimension checks so callers receive a domain-oriented
+ * {@link Optional} contract.
+ * </p>
+ */
 @Service
 public class EmbeddingService implements IEmbeddingService {
 
@@ -22,13 +52,16 @@ public class EmbeddingService implements IEmbeddingService {
   private EmbeddingAPIClient embeddingAPIClient;
   @Value("${embedding.model.name}")
   private String embeddingModelName;
-  @Value("${embedding.model.datatype}")
+  @Value("${embedding.model.datatype:float}")
   private String embeddingModelDataType;
   @Value("${embedding.model.dimension}")
   private int embeddingModelDimension;
-  @Value("${embedding.model.applicationId}")
+  @Value("${embedding.model.applicationId:lareferencia}")
   private String embeddingApplicationId;
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public Optional<List<Float>> embed(String text) {
     return callEmbeddingAPI(text)
@@ -36,17 +69,31 @@ public class EmbeddingService implements IEmbeddingService {
         .map(list -> list.get(0));
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public Optional<List<List<Float>>> embed(List<String> texts) {
     logger.info(MessageFormat.format("Count of texts for embeddings: {0}", texts.size()));
     return callEmbeddingAPI(texts);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public int getEmbeddingDimension() {
     return embeddingModelDimension;
   }
 
+  /**
+   * Calls the remote embedding API and validates the returned vectors.
+   *
+   * @param textForEmbedding source payload accepted by the API endpoint
+   *                         (single text or list of texts)
+   * @return an {@link Optional} with all returned vectors when the API call and
+   *         validation succeed, otherwise {@link Optional#empty()}
+   */
   private Optional<List<List<Float>>> callEmbeddingAPI(Object textForEmbedding) {
     try {
       EmbeddingResponse response = embeddingAPIClient.generateEmbedding(
@@ -70,7 +117,7 @@ public class EmbeddingService implements IEmbeddingService {
 
         logger.info(MessageFormat.format("Count of vectors: {0}", embeddings.size()));
 
-        var  vectorsDimension = embeddings.get(0).size();
+        var vectorsDimension = embeddings.get(0).size();
 
         if (vectorsDimension != embeddingModelDimension) {
           logger.warn(MessageFormat.format(

--- a/src/main/java/org/lareferencia/core/embedding/EmbeddingService.java
+++ b/src/main/java/org/lareferencia/core/embedding/EmbeddingService.java
@@ -74,7 +74,7 @@ public class EmbeddingService implements IEmbeddingService {
    */
   @Override
   public Optional<List<List<Float>>> embed(List<String> texts) {
-    logger.info(MessageFormat.format("Count of texts for embeddings: {0}", texts.size()));
+    logger.debug(MessageFormat.format("Count of texts for embeddings: {0}", texts.size()));
     return callEmbeddingAPI(texts);
   }
 
@@ -115,7 +115,7 @@ public class EmbeddingService implements IEmbeddingService {
           return Optional.empty();
         }
 
-        logger.info(MessageFormat.format("Count of vectors: {0}", embeddings.size()));
+        logger.debug(MessageFormat.format("Count of vectors: {0}", embeddings.size()));
 
         var vectorsDimension = embeddings.get(0).size();
 

--- a/src/main/java/org/lareferencia/core/embedding/IEmbeddingService.java
+++ b/src/main/java/org/lareferencia/core/embedding/IEmbeddingService.java
@@ -18,7 +18,7 @@
  *   For any further information please contact Lautaro Matas <lmatas@gmail.com>
  */
 
-package org.lareferencia.core.semantic.embedding;
+package org.lareferencia.core.embedding;
 
 import java.util.List;
 import java.util.Optional;
@@ -26,20 +26,26 @@ import java.util.Optional;
 /**
  * Domain-level service for semantic embedding generation.
  *
- * <p>This interface decouples the domain (workers, pipelines) from the concrete
+ * <p>
+ * This interface decouples the domain (workers, pipelines) from the concrete
  * embedding transport mechanism (HTTP, local model, etc.).
  * Multiple implementations can coexist (e.g., OpenAI-compatible HTTP API,
- * an embedded local model, a no-op stub for testing).</p>
+ * an embedded local model, a no-op stub for testing).
+ * </p>
  *
- * <p>Implementations are responsible for:</p>
+ * <p>
+ * Implementations are responsible for:
+ * </p>
  * <ul>
- *   <li>Choosing the model and encoding format</li>
- *   <li>Validating the returned vector dimension</li>
- *   <li>Handling transport-level errors and retries</li>
+ * <li>Choosing the model and encoding format</li>
+ * <li>Validating the returned vector dimension</li>
+ * <li>Handling transport-level errors and retries</li>
  * </ul>
  *
- * <p>Callers receive an {@link Optional} so they can decide the fallback strategy
- * without catching exceptions from lower layers.</p>
+ * <p>
+ * Callers receive an {@link Optional} so they can decide the fallback strategy
+ * without catching exceptions from lower layers.
+ * </p>
  */
 public interface IEmbeddingService {
 
@@ -47,10 +53,20 @@ public interface IEmbeddingService {
      * Generates a semantic embedding vector for the given text.
      *
      * @param text the text to embed (pre-truncated to model limits if necessary)
-     * @return an {@link Optional} containing the embedding vector as a list of floats,
+     * @return an {@link Optional} containing the embedding vector as a list of
+     *         floats,
      *         or {@link Optional#empty()} if generation fails for any reason
      */
     Optional<List<Float>> embed(String text);
+
+    /**
+     * Generates semantic embedding vectors for multiple texts in one request.
+     *
+     * @param texts the texts to embed
+     * @return an {@link Optional} containing one vector per input text,
+     *         or {@link Optional#empty()} if generation fails
+     */
+    Optional<List<List<Float>>> embed(List<String> texts);
 
     /**
      * Returns the configured embedding dimension for this service instance.

--- a/src/main/java/org/lareferencia/core/embedding/IEmbeddingService.java
+++ b/src/main/java/org/lareferencia/core/embedding/IEmbeddingService.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2013-2022. LA Referencia / Red CLARA and others
+ *   Copyright (c) 2013-2026. LA Referencia / Red CLARA and others
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU Affero General Public License as published by
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU Affero General Public License
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- *   This file is part of LA Referencia software platform LRHarvester v4.x
+ *   This file is part of LA Referencia software platform LRHarvester v5.x
  *   For any further information please contact Lautaro Matas <lmatas@gmail.com>
  */
 

--- a/src/main/java/org/lareferencia/core/embedding/chunks/ChunkingService.java
+++ b/src/main/java/org/lareferencia/core/embedding/chunks/ChunkingService.java
@@ -1,3 +1,23 @@
+/*
+ *   Copyright (c) 2013-2026. LA Referencia / Red CLARA and others
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   This file is part of LA Referencia software platform LRHarvester v5.x
+ *   For any further information please contact Lautaro Matas <lmatas@gmail.com>
+ */
+
 package org.lareferencia.core.embedding.chunks;
 
 import java.text.Normalizer;
@@ -11,11 +31,28 @@ import dev.langchain4j.data.document.DocumentSplitter;
 import dev.langchain4j.data.document.splitter.DocumentSplitters;
 import dev.langchain4j.data.segment.TextSegment;
 
+/**
+ * Service responsible for normalizing and splitting textual metadata into
+ * embedding-ready chunks.
+ *
+ * <p>
+ * The resulting chunks follow a title + fragment template so each segment
+ * preserves the original document context during vectorization.
+ * </p>
+ */
 @Service
 public class ChunkingService {
   private final DocumentSplitter documentSplitter;
   private final int maxChunksSize;
 
+  /**
+   * Builds a chunking service with token-aware limits.
+   *
+   * @param maxChunkSize   maximum token budget for a generated fragment
+   * @param maxOverlapSize overlap budget in tokens between consecutive fragments
+   * @param maxChunksSize  maximum number of chunks returned by
+   *                       {@link #chunkTitleAndAbstract(String, String)}
+   */
   public ChunkingService(
       @Value("${embedding.max.segment.size.tokens:128}") int maxChunkSize,
       @Value("${embedding.max.overlap.size.tokens:0}") int maxOverlapSize,
@@ -28,6 +65,13 @@ public class ChunkingService {
     this.maxChunksSize = maxChunksSize;
   }
 
+  /**
+   * Applies lightweight text normalization suitable for chunking and
+   * embedding.
+   *
+   * @param t input text, potentially null or blank
+   * @return normalized text, or an empty string when the input is null/blank
+   */
   public String normalizeText(String t) {
     if (t == null || t.isBlank()) {
       return "";
@@ -43,16 +87,20 @@ public class ChunkingService {
   }
 
   /**
-   * Recommended splitter for document title/abstract processing.
-   * 
-   * It first tries to split by paragraphs and packs as many as possible into each
-   * segment. If a paragraph is still too large, it recursively splits by lines,
-   * then
-   * sentences, then words, and finally characters until the segment fits.
+   * Splits a document abstract into chunks and prefixes each fragment with the
+   * normalized title.
    *
-   * Effective behavior is controlled by the configured splitter parameters:
-   * DEFAULT_MAX_CHUNK_SIZE, DEFAULT_MAX_OVERLAP_SIZE, and
-   * CustomTokenCountEstimator.
+   * <p>
+   * The splitter first tries to preserve larger structures (paragraphs and
+   * lines) and recursively falls back to sentences, words, and characters when
+   * needed to respect token limits.
+   * </p>
+   *
+   * @param title        document title to prepend to each chunk
+   * @param abstractText document abstract/body to split
+   * @return a list of non-blank chunks formatted as title + newline + fragment,
+   *         limited by {@code maxChunksSize}; returns an empty list for null or
+   *         blank title/abstract inputs
    */
   public List<String> chunkTitleAndAbstract(String title, String abstractText) {
     String normalizedTitle = normalizeText(title);
@@ -72,6 +120,13 @@ public class ChunkingService {
         .toList();
   }
 
+  /**
+   * Formats a chunk payload with title context.
+   *
+   * @param title    normalized title
+   * @param fragment split abstract fragment
+   * @return chunk text in two lines: title and fragment
+   */
   private static String formatChunk(String title, String fragment) {
     return title + "\n" + fragment;
   }

--- a/src/main/java/org/lareferencia/core/embedding/chunks/ChunkingService.java
+++ b/src/main/java/org/lareferencia/core/embedding/chunks/ChunkingService.java
@@ -1,0 +1,79 @@
+package org.lareferencia.core.embedding.chunks;
+
+import java.text.Normalizer;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentSplitter;
+import dev.langchain4j.data.document.splitter.DocumentSplitters;
+import dev.langchain4j.data.segment.TextSegment;
+
+@Service
+public class ChunkingService {
+  private final DocumentSplitter documentSplitter;
+  private final int maxChunksSize;
+
+  public ChunkingService(
+      @Value("${embedding.max.segment.size.tokens:128}") int maxChunkSize,
+      @Value("${embedding.max.overlap.size.tokens:0}") int maxOverlapSize,
+      @Value("${embedding.max.chunks.size:5}") int maxChunksSize) {
+    CustomTokenCountEstimator customTokenCountEstimator = new CustomTokenCountEstimator();
+    this.documentSplitter = DocumentSplitters.recursive(
+        maxChunkSize,
+        maxOverlapSize,
+        customTokenCountEstimator);
+    this.maxChunksSize = maxChunksSize;
+  }
+
+  public String normalizeText(String t) {
+    if (t == null || t.isBlank()) {
+      return "";
+    }
+    // Canonicalize Unicode so equivalent accented forms are represented
+    // consistently.
+    String n = Normalizer.normalize(t, Normalizer.Form.NFC);
+    // Join words split by hyphen + line break (common in OCR/PDF extracted text).
+    n = n.replaceAll("-\\s*\\n\\s*", "");
+    // Collapse any whitespace sequence to a single space and trim edges.
+    n = n.replaceAll("\\s+", " ").trim();
+    return n;
+  }
+
+  /**
+   * Recommended splitter for document title/abstract processing.
+   * 
+   * It first tries to split by paragraphs and packs as many as possible into each
+   * segment. If a paragraph is still too large, it recursively splits by lines,
+   * then
+   * sentences, then words, and finally characters until the segment fits.
+   *
+   * Effective behavior is controlled by the configured splitter parameters:
+   * DEFAULT_MAX_CHUNK_SIZE, DEFAULT_MAX_OVERLAP_SIZE, and
+   * CustomTokenCountEstimator.
+   */
+  public List<String> chunkTitleAndAbstract(String title, String abstractText) {
+    String normalizedTitle = normalizeText(title);
+    String normalizedAbstract = normalizeText(abstractText);
+
+    if (normalizedTitle.isBlank() || normalizedAbstract.isBlank()) {
+      return List.of();
+    }
+
+    List<TextSegment> segments = documentSplitter.split(Document.from(normalizedAbstract));
+
+    return segments.stream()
+        .map(TextSegment::text)
+        .filter(fragment -> !fragment.isBlank())
+        .limit(maxChunksSize)
+        .map(fragment -> formatChunk(normalizedTitle, fragment))
+        .toList();
+  }
+
+  private static String formatChunk(String title, String fragment) {
+    return title + "\n" + fragment;
+  }
+
+}

--- a/src/main/java/org/lareferencia/core/embedding/chunks/CustomTokenCountEstimator.java
+++ b/src/main/java/org/lareferencia/core/embedding/chunks/CustomTokenCountEstimator.java
@@ -1,3 +1,23 @@
+/*
+ *   Copyright (c) 2013-2026. LA Referencia / Red CLARA and others
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   This file is part of LA Referencia software platform LRHarvester v5.x
+ *   For any further information please contact Lautaro Matas <lmatas@gmail.com>
+ */
+
 package org.lareferencia.core.embedding.chunks;
 
 import java.util.regex.Matcher;
@@ -11,8 +31,11 @@ import dev.langchain4j.model.TokenCountEstimator;
 /**
  * Lightweight estimator designed for semantic chunking when a model tokenizer
  * is unavailable.
+ *
+ * <p>
  * The strategy blends lexical units, punctuation and CJK-aware character
- * counts.
+ * counts to approximate token budgets for splitter decisions.
+ * </p>
  */
 @Component
 public class CustomTokenCountEstimator implements TokenCountEstimator {
@@ -20,6 +43,12 @@ public class CustomTokenCountEstimator implements TokenCountEstimator {
     private static final Pattern WORD_OR_NUMBER = Pattern.compile("[\\p{L}\\p{N}]+(?:['’-][\\p{L}\\p{N}]+)*");
     private static final Pattern PUNCTUATION = Pattern.compile("[\\p{Punct}]");
 
+    /**
+     * Estimates token count for plain text.
+     *
+     * @param text source text
+     * @return estimated token count; returns 0 for null/blank input
+     */
     @Override
     public int estimateTokenCountInText(String text) {
         if (text == null || text.isBlank()) {
@@ -40,6 +69,14 @@ public class CustomTokenCountEstimator implements TokenCountEstimator {
         return count;
     }
 
+    /**
+     * Estimates token count for supported LangChain4j message types.
+     *
+     * @param message chat message to inspect
+     * @return estimated token count; returns 0 for null message
+     * @throws IllegalArgumentException if the message type is not recognized by
+     *                                  this estimator
+     */
     @Override
     public int estimateTokenCountInMessage(ChatMessage message) {
         if (message == null) {
@@ -59,6 +96,12 @@ public class CustomTokenCountEstimator implements TokenCountEstimator {
         throw new IllegalArgumentException("Unknown message type: " + message.getClass().getName());
     }
 
+    /**
+     * Aggregates token estimates for a collection of chat messages.
+     *
+     * @param messages iterable message collection
+     * @return total estimated tokens across all messages
+     */
     @Override
     public int estimateTokenCountInMessages(Iterable<ChatMessage> messages) {
         int tokens = 0;
@@ -68,6 +111,13 @@ public class CustomTokenCountEstimator implements TokenCountEstimator {
         return tokens;
     }
 
+    /**
+     * Counts regex matches in a text.
+     *
+     * @param pattern compiled pattern to apply
+     * @param text    source text
+     * @return number of matches
+     */
     private static int countMatches(Pattern pattern, String text) {
         Matcher matcher = pattern.matcher(text);
         int count = 0;
@@ -77,6 +127,12 @@ public class CustomTokenCountEstimator implements TokenCountEstimator {
         return count;
     }
 
+    /**
+     * Counts code points that belong to CJK-related Unicode blocks.
+     *
+     * @param text source text
+     * @return number of CJK code points detected in the text
+     */
     private static int countCjkCodePoints(String text) {
         int count = 0;
         for (int i = 0; i < text.length();) {
@@ -90,6 +146,12 @@ public class CustomTokenCountEstimator implements TokenCountEstimator {
         return count;
     }
 
+    /**
+     * Indicates whether a Unicode block should be treated as CJK for estimation.
+     *
+     * @param block Unicode block to evaluate
+     * @return true when the block belongs to supported CJK families
+     */
     private static boolean isCjkBlock(Character.UnicodeBlock block) {
         return block == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS
                 || block == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A

--- a/src/main/java/org/lareferencia/core/embedding/chunks/CustomTokenCountEstimator.java
+++ b/src/main/java/org/lareferencia/core/embedding/chunks/CustomTokenCountEstimator.java
@@ -1,0 +1,105 @@
+package org.lareferencia.core.embedding.chunks;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Component;
+
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.model.TokenCountEstimator;
+
+/**
+ * Lightweight estimator designed for semantic chunking when a model tokenizer
+ * is unavailable.
+ * The strategy blends lexical units, punctuation and CJK-aware character
+ * counts.
+ */
+@Component
+public class CustomTokenCountEstimator implements TokenCountEstimator {
+
+    private static final Pattern WORD_OR_NUMBER = Pattern.compile("[\\p{L}\\p{N}]+(?:['’-][\\p{L}\\p{N}]+)*");
+    private static final Pattern PUNCTUATION = Pattern.compile("[\\p{Punct}]");
+
+    @Override
+    public int estimateTokenCountInText(String text) {
+        if (text == null || text.isBlank()) {
+            return 0;
+        }
+
+        int wordsAndNumbers = countMatches(WORD_OR_NUMBER, text);
+        int punctuation = countMatches(PUNCTUATION, text);
+        int cjkChars = countCjkCodePoints(text);
+
+        // Approximation tuned for transformer BPE tokenization:
+        // - base lexical units
+        // - punctuation contributes as standalone tokens in many vocabularies
+        // - CJK scripts typically split into more granular units
+        double estimate = (wordsAndNumbers * 1.10d) + (punctuation * 0.35d) + (cjkChars * 0.65d);
+
+        int count = Math.max(1, (int) Math.ceil(estimate));
+        return count;
+    }
+
+    @Override
+    public int estimateTokenCountInMessage(ChatMessage message) {
+        if (message == null) {
+            return 0;
+        }
+
+        if (message instanceof dev.langchain4j.data.message.SystemMessage systemMessage) {
+            return estimateTokenCountInText(systemMessage.text());
+        } else if (message instanceof dev.langchain4j.data.message.UserMessage userMessage) {
+            return estimateTokenCountInText(userMessage.singleText());
+        } else if (message instanceof dev.langchain4j.data.message.AiMessage aiMessage) {
+            return estimateTokenCountInText(aiMessage.text());
+        } else if (message instanceof dev.langchain4j.data.message.ToolExecutionResultMessage toolExecutionResultMessage) {
+            return estimateTokenCountInText(toolExecutionResultMessage.text());
+        }
+
+        throw new IllegalArgumentException("Unknown message type: " + message.getClass().getName());
+    }
+
+    @Override
+    public int estimateTokenCountInMessages(Iterable<ChatMessage> messages) {
+        int tokens = 0;
+        for (ChatMessage message : messages) {
+            tokens += estimateTokenCountInMessage(message);
+        }
+        return tokens;
+    }
+
+    private static int countMatches(Pattern pattern, String text) {
+        Matcher matcher = pattern.matcher(text);
+        int count = 0;
+        while (matcher.find()) {
+            count++;
+        }
+        return count;
+    }
+
+    private static int countCjkCodePoints(String text) {
+        int count = 0;
+        for (int i = 0; i < text.length();) {
+            int codePoint = text.codePointAt(i);
+            Character.UnicodeBlock block = Character.UnicodeBlock.of(codePoint);
+            if (isCjkBlock(block)) {
+                count++;
+            }
+            i += Character.charCount(codePoint);
+        }
+        return count;
+    }
+
+    private static boolean isCjkBlock(Character.UnicodeBlock block) {
+        return block == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS
+                || block == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A
+                || block == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS_EXTENSION_B
+                || block == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS_EXTENSION_C
+                || block == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS_EXTENSION_D
+                || block == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS_EXTENSION_E
+                || block == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS_EXTENSION_F
+                || block == Character.UnicodeBlock.HIRAGANA
+                || block == Character.UnicodeBlock.KATAKANA
+                || block == Character.UnicodeBlock.HANGUL_SYLLABLES;
+    }
+}

--- a/src/main/java/org/lareferencia/core/embedding/client/EmbeddingAPIClient.java
+++ b/src/main/java/org/lareferencia/core/embedding/client/EmbeddingAPIClient.java
@@ -18,28 +18,37 @@
  *   For any further information please contact Lautaro Matas <lmatas@gmail.com>
  */
 
-package org.lareferencia.core.semantic.embedding.client;
+package org.lareferencia.core.embedding.client;
 
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.service.annotation.PostExchange;
 
 /**
- * Declarative HTTP client for the semantic vector embedding API (Spring 6 HTTP Interface).
+ * Declarative HTTP client for the semantic vector embedding API (Spring 6 HTTP
+ * Interface).
  *
- * <p>This is a low-level transport interface that maps directly to the OpenAI-compatible
- * embedding endpoint. It should <strong>not</strong> be used directly by domain components
- * (workers, pipelines). Use {@link org.lareferencia.core.semantic.embedding.IEmbeddingService}
- * instead.</p>
+ * <p>
+ * This is a low-level transport interface that maps directly to the
+ * OpenAI-compatible
+ * embedding endpoint. It should <strong>not</strong> be used directly by domain
+ * components
+ * (workers, pipelines). Use
+ * {@link org.lareferencia.core.embedding.IEmbeddingService}
+ * instead.
+ * </p>
  *
- * <p>The bean is instantiated and configured by
- * {@link org.lareferencia.core.semantic.embedding.config.SemanticVectorAPIConfig}.</p>
+ * <p>
+ * The bean is instantiated and configured by
+ * {@link org.lareferencia.core.EmbeddingAPIConfig.embedding.config.SemanticVectorAPIConfig}.
+ * </p>
  */
-public interface SemanticVectorAPIClient {
+public interface EmbeddingAPIClient {
 
     /**
      * Calls the remote embedding endpoint and returns the raw API response.
      *
-     * @param request the embedding request payload (model, input, format, dimensions)
+     * @param request the embedding request payload (model, input, format,
+     *                dimensions)
      * @return the raw API response containing one or more embedding vectors
      */
     @PostExchange("")

--- a/src/main/java/org/lareferencia/core/embedding/client/EmbeddingData.java
+++ b/src/main/java/org/lareferencia/core/embedding/client/EmbeddingData.java
@@ -18,26 +18,23 @@
  *   For any further information please contact Lautaro Matas <lmatas@gmail.com>
  */
 
-package org.lareferencia.core.semantic.embedding.client;
+package org.lareferencia.core.embedding.client;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
- * DTO for API token usage statistics (OpenAI-compatible format).
+ * DTO for a single embedding item (OpenAI-compatible format).
  */
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class Usage {
-
-    @JsonProperty("prompt_tokens")
-    private int promptTokens;
-
-    @JsonProperty("total_tokens")
-    private int totalTokens;
+public class EmbeddingData {
+    private String object;
+    private List<Float> embedding;
+    private int index;
 }

--- a/src/main/java/org/lareferencia/core/embedding/client/EmbeddingRequest.java
+++ b/src/main/java/org/lareferencia/core/embedding/client/EmbeddingRequest.java
@@ -18,24 +18,27 @@
  *   For any further information please contact Lautaro Matas <lmatas@gmail.com>
  */
 
-package org.lareferencia.core.semantic.embedding.client;
+package org.lareferencia.core.embedding.client;
 
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
- * DTO for the embedding generation response (OpenAI-compatible format).
+ * DTO for the embedding generation request (OpenAI-compatible format).
  */
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class EmbeddingResponse {
-    private String object;
-    private List<EmbeddingItem> data;
+public class EmbeddingRequest {
+    private Object input;
     private String model;
-    private Usage usage;
+    @JsonProperty("encoding_format")
+    private String encodingFormat;
+    private Integer dimensions;
+    private String user;
 }

--- a/src/main/java/org/lareferencia/core/embedding/client/EmbeddingResponse.java
+++ b/src/main/java/org/lareferencia/core/embedding/client/EmbeddingResponse.java
@@ -18,26 +18,24 @@
  *   For any further information please contact Lautaro Matas <lmatas@gmail.com>
  */
 
-package org.lareferencia.core.semantic.embedding.client;
+package org.lareferencia.core.embedding.client;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
- * DTO for the embedding generation request (OpenAI-compatible format).
+ * DTO for the embedding generation response (OpenAI-compatible format).
  */
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class EmbeddingRequest {
-    private String input;
+public class EmbeddingResponse {
+    private String object;
+    private List<EmbeddingData> data;
     private String model;
-    @JsonProperty("encoding_format")
-    private String encodingFormat;
-    private Integer dimensions;
-    private String user;
+    private Usage usage;
 }

--- a/src/main/java/org/lareferencia/core/embedding/client/Usage.java
+++ b/src/main/java/org/lareferencia/core/embedding/client/Usage.java
@@ -18,23 +18,26 @@
  *   For any further information please contact Lautaro Matas <lmatas@gmail.com>
  */
 
-package org.lareferencia.core.semantic.embedding.client;
+package org.lareferencia.core.embedding.client;
 
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
- * DTO for a single embedding item (OpenAI-compatible format).
+ * DTO for API token usage statistics (OpenAI-compatible format).
  */
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class EmbeddingItem {
-    private String object;
-    private List<Float> embedding;
-    private int index;
+public class Usage {
+
+    @JsonProperty("prompt_tokens")
+    private int promptTokens;
+
+    @JsonProperty("total_tokens")
+    private int totalTokens;
 }

--- a/src/main/java/org/lareferencia/core/embedding/config/EmbeddingAPIConfig.java
+++ b/src/main/java/org/lareferencia/core/embedding/config/EmbeddingAPIConfig.java
@@ -54,7 +54,7 @@ public class EmbeddingAPIConfig {
         @Value("${embedding.api.url:http://localhost:11434/api}")
         private String embeddingApiUrl;
 
-        @Value("${embedding.api.timeout.seconds:60}")
+        @Value("${embedding.api.timeout.seconds:30}")
         private int embeddingApiTimeoutSeconds;
 
         @Value("${embedding.api.key:}")

--- a/src/main/java/org/lareferencia/core/embedding/config/EmbeddingAPIConfig.java
+++ b/src/main/java/org/lareferencia/core/embedding/config/EmbeddingAPIConfig.java
@@ -18,17 +18,18 @@
  *   For any further information please contact Lautaro Matas <lmatas@gmail.com>
  */
 
-package org.lareferencia.core.semantic.embedding.config;
+package org.lareferencia.core.embedding.config;
 
 import java.time.Duration;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.lareferencia.core.semantic.embedding.client.SemanticVectorAPIClient;
+import org.lareferencia.core.embedding.client.EmbeddingAPIClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.support.WebClientAdapter;
 import org.springframework.web.service.invoker.HttpServiceProxyFactory;
@@ -41,27 +42,30 @@ import reactor.util.retry.Retry;
  * Spring configuration for the semantic vector embedding infrastructure.
  *
  * <p>
- * Registers the {@link SemanticVectorAPIClient} bean with a resilient WebClient
+ * Registers the {@link EmbeddingAPIClient} bean with a resilient WebClient
  * (configurable timeout + exponential back-off retry).
  * </p>
  */
 @Configuration
-public class SemanticVectorAPIConfig {
+public class EmbeddingAPIConfig {
 
-        private static final Logger logger = LogManager.getLogger(SemanticVectorAPIConfig.class);
+        private static final Logger logger = LogManager.getLogger(EmbeddingAPIConfig.class);
 
         @Value("${embedding.api.url:http://localhost:11434/api}")
         private String embeddingApiUrl;
 
-        @Value("${embedding.api.timeout.seconds:30}")
+        @Value("${embedding.api.timeout.seconds:60}")
         private int embeddingApiTimeoutSeconds;
 
+        @Value("${embedding.api.key:}")
+        private String embeddingApiKey;
+
         @Bean
-        public SemanticVectorAPIClient semanticVectorAPIClient() {
+        public EmbeddingAPIClient semanticVectorAPIClient() {
                 HttpClient httpClient = HttpClient.create()
                                 .responseTimeout(Duration.ofSeconds(embeddingApiTimeoutSeconds));
 
-                Retry retryStrategy = Retry.backoff(3, Duration.ofSeconds(1))
+                Retry retryStrategy = Retry.backoff(3, Duration.ofSeconds(5))
                                 .jitter(0.75)
                                 .doBeforeRetry(retrySignal -> logger.warn(
                                                 "Retrying embedding API call. Attempt: {}. Cause: {}",
@@ -72,7 +76,12 @@ public class SemanticVectorAPIConfig {
                                 .baseUrl(embeddingApiUrl)
                                 .clientConnector(new ReactorClientHttpConnector(httpClient))
                                 .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(16 * 1024 * 1024))
-                                .defaultHeaders(headers -> headers.set("Content-Type", "application/json"))
+                                .defaultHeaders(headers -> {
+                                        headers.set("Content-Type", "application/json");
+                                        if (StringUtils.hasText(embeddingApiKey)) {
+                                                headers.setBearerAuth(embeddingApiKey);
+                                        }
+                                })
                                 .filter((request, next) -> next.exchange(request)
                                                 .flatMap(response -> {
                                                         if (!response.statusCode().is2xxSuccessful()) {
@@ -87,6 +96,6 @@ public class SemanticVectorAPIConfig {
                                 .exchangeAdapter(WebClientAdapter.create(webClient))
                                 .build();
 
-                return factory.createClient(SemanticVectorAPIClient.class);
+                return factory.createClient(EmbeddingAPIClient.class);
         }
 }

--- a/src/main/java/org/lareferencia/core/worker/indexing/SemanticIndexerWorker.java
+++ b/src/main/java/org/lareferencia/core/worker/indexing/SemanticIndexerWorker.java
@@ -37,8 +37,9 @@ import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.common.SolrInputDocument;
-import org.lareferencia.core.semantic.embedding.IEmbeddingService;
 import org.lareferencia.core.domain.SnapshotIndexStatus;
+import org.lareferencia.core.embedding.IEmbeddingService;
+import org.lareferencia.core.embedding.chunks.ChunkingService;
 import org.lareferencia.core.metadata.IMDFormatTransformer;
 import org.lareferencia.core.metadata.IMetadataStore;
 import org.lareferencia.core.metadata.ISnapshotStore;
@@ -102,14 +103,15 @@ public class SemanticIndexerWorker extends BaseBatchWorker<ValidationRecord, Net
 	@Autowired
 	private IEmbeddingService embeddingService;
 
+	@Autowired
+	private ChunkingService chunkingService;
+
 	private IMDFormatTransformer metadataTransformer;
 
 	private HttpSolrClient solrClient;
 
 	@Value("${frontend.solr.url}")
 	private String solrURL;
-
-
 
 	@Setter
 	private boolean useMultiValuedVector;
@@ -145,7 +147,10 @@ public class SemanticIndexerWorker extends BaseBatchWorker<ValidationRecord, Net
 	private String embeddingApiUrl;
 	@Setter
 	@Getter
-	private String sourceFieldForEmbedding;
+	private String titleFieldForEmbedding;
+	@Setter
+	@Getter
+	private String abstractFieldForEmbedding;
 	@Setter
 	@Getter
 	private String vectorFieldName;
@@ -208,7 +213,7 @@ public class SemanticIndexerWorker extends BaseBatchWorker<ValidationRecord, Net
 				Document transformedDoc = metadataTransformer.transform(metadata.getDOMDocument());
 				SolrInputDocument solrDoc = xmlDocumentToSolrInputDocument(transformedDoc);
 
-				enrichRecordWithEmbedding(solrDoc, metadata, record.getIdentifierHash());
+				enrichRecordWithEmbedding(solrDoc, metadata);
 				documentsToBeIndexed.add(solrDoc);
 				logger.debug(MessageFormat.format("Transformed record to be indexed: {0} :: {1}", record.getIdentifierHash(),
 						record.getIdentifier()));
@@ -275,7 +280,7 @@ public class SemanticIndexerWorker extends BaseBatchWorker<ValidationRecord, Net
 					this.targetSchemaName));
 			logInfo(MessageFormat.format("Indexed documents in {0}::{1} = {2}", runningContext.getNetwork().getAcronym(),
 					this.targetSchemaName, this.queryForNetworkDocumentCount(runningContext.getNetwork().getAcronym())));
-			logInfo(MessageFormat.format("Embedding stats - Success: {0} | Failed: {1}", embeddedRecordsCount,
+			logInfo(MessageFormat.format("Embedding stats: Success: {0} | Failed: {1}", (embeddedRecordsCount - failedEmbeddingsCount),
 					failedEmbeddingsCount));
 
 			logger.debug(MessageFormat.format("Updates snapshot status to {0}", SnapshotIndexStatus.INDEXED));
@@ -315,8 +320,8 @@ public class SemanticIndexerWorker extends BaseBatchWorker<ValidationRecord, Net
 
 		logger.debug(MessageFormat.format("Full semantic indexing ({0}): {1}", this.targetSchemaName, snapshotId));
 		logInfo(MessageFormat.format("Full semantic indexing: {0}({1})", runningContext.toString(), this.targetSchemaName));
-		logInfo(MessageFormat.format("Embedding API: {0} | Source field: {1} | Vector field: {2}", embeddingApiUrl,
-				sourceFieldForEmbedding, vectorFieldName));
+		logInfo(MessageFormat.format("Embedding API: {0} | Title field: {1} | Abstract field: {2} | Vector field: {3}",
+				embeddingApiUrl, titleFieldForEmbedding, abstractFieldForEmbedding, vectorFieldName));
 
 		return initializeTransformer();
 	}
@@ -392,65 +397,41 @@ public class SemanticIndexerWorker extends BaseBatchWorker<ValidationRecord, Net
 		metadataTransformer.setParameter("metadata", metadata.toString());
 	}
 
-	private void enrichRecordWithEmbedding(SolrInputDocument recordDoc, OAIRecordMetadata metadata,
-			String recordIdentifier) {
-		List<List<Float>> vectors = new ArrayList<>();
-
-		List<String> metadataValues = new ArrayList<>();
-		for (String metadataField : sourceFieldForEmbedding.split(",")) {
-			String textForEmbedding = extractMetataValue(metadata, metadataField.trim());
-			metadataValues.add(textForEmbedding);
+	/**
+	 * Solr DenseVector multivalued fields expect an array of vectors [[...], [...]]
+	 * while single-valued fields expect a single vector [...].
+	 */
+	private void enrichRecordWithEmbedding(SolrInputDocument recordDoc, OAIRecordMetadata metadata) {
+		String title = extractMetadataValue(metadata, titleFieldForEmbedding);
+		if (title.isBlank()) {
+			return;
 		}
 
 		if (useMultiValuedVector) {
-			metadataValues.forEach(textForEmbedding -> {
-				List<Float> embedding = callEmbeddingAPI(recordIdentifier, truncEmbeddingTextIfNeeded(textForEmbedding));
-				if (embedding != null) {
-					vectors.add(embedding);
-				}
-			});
+			String abstractText = extractMetadataValue(metadata, abstractFieldForEmbedding);
+			List<String> textsToEmbedding = new ArrayList<>();
+			textsToEmbedding.add(title);
+
+            textsToEmbedding.addAll(chunkingService.chunkTitleAndAbstract(title, abstractText));
+
+			embeddingService.embed(textsToEmbedding)
+					.filter(vectors -> !vectors.isEmpty())
+					.ifPresentOrElse(
+							vectors -> recordDoc.setField(vectorFieldName, vectors),
+							() -> logEmbeddingFailure(title));
 		} else {
-			List<Float> embedding = callEmbeddingAPI(recordIdentifier,
-					truncEmbeddingTextIfNeeded(String.join(" ", metadataValues)));
-			if (embedding != null) {
-				vectors.add(embedding);
-			}
+			embeddingService.embed(title)
+					.filter(vector -> !vector.isEmpty())
+					.ifPresentOrElse(
+							vector -> recordDoc.setField(vectorFieldName, vector),
+							() -> logEmbeddingFailure(title));
 		}
-
-		if (!vectors.isEmpty()) {
-			// Solr DenseVector multivalued field expects array of vectors: [[...],[...]].
-			recordDoc.setField(vectorFieldName, vectors);
-		}
-
+        embeddedRecordsCount++;
 	}
 
-	/**
-	 * Delegates embedding generation to {@link IEmbeddingService}.
-	 * The service handles model selection, HTTP transport, retries, and dimension validation.
-	 * The worker only counts successes/failures and applies its own skip-on-failure policy.
-	 *
-	 * @param recordIdentifier identifier used for logging
-	 * @param textForEmbedding pre-truncated text to embed
-	 * @return the embedding vector, or {@code null} if unavailable
-	 */
-	private List<Float> callEmbeddingAPI(String recordIdentifier, String textForEmbedding) {
-		if (textForEmbedding == null || textForEmbedding.trim().isEmpty()) {
-			logger.debug(MessageFormat.format(
-					"Skipping embedding for record {0}: empty source text", recordIdentifier));
-			return null;
-		}
-
-		return embeddingService.embed(textForEmbedding)
-				.map(vector -> {
-					embeddedRecordsCount++;
-					return vector;
-				})
-				.orElseGet(() -> {
-					failedEmbeddingsCount++;
-					logger.warn(MessageFormat.format(
-							"Failed to generate embedding for record: {0}", recordIdentifier));
-					return null;
-				});
+	private void logEmbeddingFailure(String title) {
+        failedEmbeddingsCount++;
+		logger.warn(MessageFormat.format("Failed to generate embedding for record: {0}", title));
 	}
 
 	/**
@@ -540,7 +521,7 @@ public class SemanticIndexerWorker extends BaseBatchWorker<ValidationRecord, Net
 	 * @param metadata the OAI record metadata
 	 * @return concatenated text from source field, or null if empty
 	 */
-	private String extractMetataValue(OAIRecordMetadata metadata, String metadataField) {
+	private String extractMetadataValue(OAIRecordMetadata metadata, String metadataField) {
 		List<String> occurrences = metadata.getFieldOcurrences(metadataField);
 		if (occurrences == null || occurrences.isEmpty()) {
 			return "";
@@ -551,18 +532,6 @@ public class SemanticIndexerWorker extends BaseBatchWorker<ValidationRecord, Net
 				.filter(metadataValue -> !metadataValue.trim().isEmpty())
 				.collect(Collectors.joining(" "));
 
-	}
-
-	private static String truncEmbeddingTextIfNeeded(String text) {
-		if (text.length() > MAX_EMBEDDING_TEXT_LENGTH) {
-			String truncated = text.substring(0, MAX_EMBEDDING_TEXT_LENGTH);
-			int lastSpaceIndex = truncated.lastIndexOf(' ');
-
-			if (lastSpaceIndex != -1) {
-				return truncated.substring(0, lastSpaceIndex).trim();
-			}
-		}
-		return text;
 	}
 
 	private SolrInputDocument xmlDocumentToSolrInputDocument(Document doc) {

--- a/src/main/java/org/lareferencia/core/worker/indexing/SemanticIndexerWorker.java
+++ b/src/main/java/org/lareferencia/core/worker/indexing/SemanticIndexerWorker.java
@@ -113,9 +113,6 @@ public class SemanticIndexerWorker extends BaseBatchWorker<ValidationRecord, Net
 	@Value("${frontend.solr.url}")
 	private String solrURL;
 
-	@Setter
-	private boolean useMultiValuedVector;
-
 	private Long snapshotId;
 	private SnapshotMetadata snapshotMetadata;
 	private int recordCounter = 0;
@@ -144,22 +141,23 @@ public class SemanticIndexerWorker extends BaseBatchWorker<ValidationRecord, Net
 	private Map<String, List<String>> contentFiltersByFieldName = null;
 	@Setter
 	@Getter
+	@Value("${embedding.api.url:}")
 	private String embeddingApiUrl;
 	@Setter
 	@Getter
+	@Value("${embedding.title.field:dc.title.*}")
 	private String titleFieldForEmbedding;
 	@Setter
 	@Getter
+	@Value("${embedding.abstract.field:dc.description.*}")
 	private String abstractFieldForEmbedding;
 	@Setter
 	@Getter
+	@Value("${embedding.vector.field.name:vector_multivalued}")
 	private String vectorFieldName;
+	@Value("${embedding.use.multivalued.vector:false}")
 	@Setter
-	@Getter
-	private int embeddingApiTimeoutSeconds = 30;
-	@Setter
-	@Getter
-	private boolean skipOnEmbeddingFailure = true;
+	private boolean useMultiValuedVector;
 
 	public SemanticIndexerWorker() {
 		super();
@@ -280,7 +278,8 @@ public class SemanticIndexerWorker extends BaseBatchWorker<ValidationRecord, Net
 					this.targetSchemaName));
 			logInfo(MessageFormat.format("Indexed documents in {0}::{1} = {2}", runningContext.getNetwork().getAcronym(),
 					this.targetSchemaName, this.queryForNetworkDocumentCount(runningContext.getNetwork().getAcronym())));
-			logInfo(MessageFormat.format("Embedding stats: Success: {0} | Failed: {1}", (embeddedRecordsCount - failedEmbeddingsCount),
+			logInfo(MessageFormat.format("Embedding stats: Success: {0} | Failed: {1}",
+					(embeddedRecordsCount - failedEmbeddingsCount),
 					failedEmbeddingsCount));
 
 			logger.debug(MessageFormat.format("Updates snapshot status to {0}", SnapshotIndexStatus.INDEXED));
@@ -412,7 +411,7 @@ public class SemanticIndexerWorker extends BaseBatchWorker<ValidationRecord, Net
 			List<String> textsToEmbedding = new ArrayList<>();
 			textsToEmbedding.add(title);
 
-            textsToEmbedding.addAll(chunkingService.chunkTitleAndAbstract(title, abstractText));
+			textsToEmbedding.addAll(chunkingService.chunkTitleAndAbstract(title, abstractText));
 
 			embeddingService.embed(textsToEmbedding)
 					.filter(vectors -> !vectors.isEmpty())
@@ -426,11 +425,11 @@ public class SemanticIndexerWorker extends BaseBatchWorker<ValidationRecord, Net
 							vector -> recordDoc.setField(vectorFieldName, vector),
 							() -> logEmbeddingFailure(title));
 		}
-        embeddedRecordsCount++;
+		embeddedRecordsCount++;
 	}
 
 	private void logEmbeddingFailure(String title) {
-        failedEmbeddingsCount++;
+		failedEmbeddingsCount++;
 		logger.warn(MessageFormat.format("Failed to generate embedding for record: {0}", title));
 	}
 

--- a/src/main/java/org/lareferencia/core/worker/indexing/SemanticIndexerWorker.java
+++ b/src/main/java/org/lareferencia/core/worker/indexing/SemanticIndexerWorker.java
@@ -420,7 +420,7 @@ public class SemanticIndexerWorker extends BaseBatchWorker<ValidationRecord, Net
 							vectors -> recordDoc.setField(vectorFieldName, vectors),
 							() -> logEmbeddingFailure(title));
 		} else {
-			embeddingService.embed(title)
+			embeddingService.embed(chunkingService.normalizeText(title))
 					.filter(vector -> !vector.isEmpty())
 					.ifPresentOrElse(
 							vector -> recordDoc.setField(vectorFieldName, vector),

--- a/src/test/java/org/lareferencia/core/service/ChunkingServiceTest.java
+++ b/src/test/java/org/lareferencia/core/service/ChunkingServiceTest.java
@@ -1,0 +1,144 @@
+package org.lareferencia.core.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.lareferencia.core.embedding.chunks.ChunkingService;
+
+class ChunkingServiceTest {
+
+  private static final int TEST_MAX_CHUNK_SIZE = 128;
+  private static final int TEST_MAX_OVERLAP_SIZE = 0;
+  private static final int TEST_MAX_CHUNKS_SIZE = 5;
+
+  private static final Pattern WORD_PATTERN = Pattern.compile("\\s+");
+
+  private final ChunkingService chunkingService = new ChunkingService(TEST_MAX_CHUNK_SIZE, TEST_MAX_OVERLAP_SIZE,
+      TEST_MAX_CHUNKS_SIZE);
+
+  @Test
+  void shouldFormatSingleChunkExactlyForShortAbstract() {
+    String title = "Transformer Architectures for Multilingual Repositories";
+    String abstractText = "This paper presents a semantic metadata alignment strategy for institutional repositories.";
+
+    List<String> chunks = chunkingService.chunkTitleAndAbstract(title, abstractText);
+
+    assertEquals(1, chunks.size());
+    assertEquals(
+        title + "\n" + abstractText,
+        chunks.get(0));
+  }
+
+  @Test
+  void shouldSplitLongAbstractIntoExpectedChunkRangeAndPreserveTemplate() {
+    String title = "Semantic Interoperability in Regional Open Access Networks";
+    String abstractText = buildLongAbstract(4, 65);
+
+    List<String> chunks = chunkingService.chunkTitleAndAbstract(title, abstractText);
+
+    assertTrue(chunks.size() >= 2, "Expected long abstract to produce multiple chunks");
+    assertTrue(chunks.size() <= TEST_MAX_CHUNKS_SIZE,
+        "Expected chunk count to respect configured upper bound");
+
+    for (String chunk : chunks) {
+      assertTrue(chunk.startsWith(title + "\n"));
+      assertFalse(chunk.substring((title + "\n").length()).isBlank());
+    }
+  }
+
+  @Test
+  void shouldRespectConfiguredOverlapBoundaryBetweenConsecutiveChunks() {
+    String title = "Cross-Repository Semantic Similarity";
+    String abstractText = buildSingleSentenceAbstract(320);
+
+    List<String> chunks = chunkingService.chunkTitleAndAbstract(title, abstractText);
+    assertTrue(chunks.size() >= 2, "Test requires at least two chunks to evaluate overlap");
+
+    for (int i = 0; i < chunks.size() - 1; i++) {
+      String currentFragment = extractFragment(chunks.get(i));
+      String nextFragment = extractFragment(chunks.get(i + 1));
+
+      List<String> currentWords = words(currentFragment);
+      List<String> nextWords = words(nextFragment);
+
+      List<String> currentTail = currentWords.subList(Math.max(0, currentWords.size() - 30), currentWords.size());
+      Set<String> nextSet = nextWords.stream().collect(Collectors.toSet());
+
+      long sharedCount = currentTail.stream().filter(nextSet::contains).count();
+
+      assertTrue(sharedCount <= TEST_MAX_OVERLAP_SIZE,
+          "Observed overlap should not exceed configured overlap boundary");
+    }
+  }
+
+  @Test
+  void shouldRespectConfiguredMaxChunksLimit() {
+    ChunkingService limitedChunkingService = new ChunkingService(TEST_MAX_CHUNK_SIZE, TEST_MAX_OVERLAP_SIZE, 2);
+    String title = "Chunk limit test";
+    String abstractText = buildLongAbstract(6, 80);
+
+    List<String> chunks = limitedChunkingService.chunkTitleAndAbstract(title, abstractText);
+    assertTrue(chunks.size() <= 2, "Expected chunk count to be capped by configured max chunks");
+  }
+
+  @Test
+  void shouldHandleNullOrBlankInputsGracefully() {
+    assertTrue(chunkingService.chunkTitleAndAbstract(null, "valid").isEmpty());
+    assertTrue(chunkingService.chunkTitleAndAbstract(" ", "valid").isEmpty());
+    assertTrue(chunkingService.chunkTitleAndAbstract("valid", null).isEmpty());
+    assertTrue(chunkingService.chunkTitleAndAbstract("valid", " \n\t ").isEmpty());
+  }
+
+  private static String extractFragment(String chunk) {
+    int index = chunk.indexOf('\n');
+    return chunk.substring(index + 1);
+  }
+
+  private static List<String> words(String text) {
+    return Arrays.stream(WORD_PATTERN.split(text.trim()))
+        .filter(token -> !token.isBlank())
+        .map(token -> token.replaceAll("[^a-zA-Z0-9_-]", ""))
+        .filter(token -> !token.isBlank())
+        .toList();
+  }
+
+  private static String buildLongAbstract(int sentenceCount, int wordsPerSentence) {
+    StringBuilder sb = new StringBuilder();
+
+    int token = 1;
+    for (int sentence = 1; sentence <= sentenceCount; sentence++) {
+      sb.append("Sentence ").append(sentence).append(" discusses semantic indexing relevance ");
+
+      for (int word = 1; word <= wordsPerSentence; word++) {
+        sb.append("token").append(token++).append(' ');
+      }
+
+      sb.append("for regional repositories and multilingual discovery.");
+      if (sentence < sentenceCount) {
+        sb.append(' ');
+      }
+    }
+
+    return sb.toString();
+  }
+
+  private static String buildSingleSentenceAbstract(int words) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 1; i <= words; i++) {
+      sb.append("token").append(i);
+      if (i < words) {
+        sb.append(' ');
+      }
+    }
+    sb.append('.');
+    return sb.toString();
+  }
+}

--- a/src/test/java/org/lareferencia/core/service/ChunkingServiceTest.java
+++ b/src/test/java/org/lareferencia/core/service/ChunkingServiceTest.java
@@ -1,3 +1,23 @@
+/*
+ *   Copyright (c) 2013-2026. LA Referencia / Red CLARA and others
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   This file is part of LA Referencia software platform LRHarvester v5.x
+ *   For any further information please contact Lautaro Matas <lmatas@gmail.com>
+ */
+
 package org.lareferencia.core.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -13,6 +33,14 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.lareferencia.core.embedding.chunks.ChunkingService;
 
+/**
+ * Unit tests for {@link ChunkingService} chunk generation behavior.
+ *
+ * <p>
+ * The suite validates formatting, boundary constraints, overlap expectations,
+ * and null/blank input handling with deterministic synthetic abstracts.
+ * </p>
+ */
 class ChunkingServiceTest {
 
   private static final int TEST_MAX_CHUNK_SIZE = 128;
@@ -24,6 +52,10 @@ class ChunkingServiceTest {
   private final ChunkingService chunkingService = new ChunkingService(TEST_MAX_CHUNK_SIZE, TEST_MAX_OVERLAP_SIZE,
       TEST_MAX_CHUNKS_SIZE);
 
+  /**
+   * Verifies that short abstracts are kept in a single chunk with exact
+   * title-fragment formatting.
+   */
   @Test
   void shouldFormatSingleChunkExactlyForShortAbstract() {
     String title = "Transformer Architectures for Multilingual Repositories";
@@ -37,6 +69,10 @@ class ChunkingServiceTest {
         chunks.get(0));
   }
 
+  /**
+   * Verifies that long abstracts are split into multiple chunks and keep the
+   * required title prefix template.
+   */
   @Test
   void shouldSplitLongAbstractIntoExpectedChunkRangeAndPreserveTemplate() {
     String title = "Semantic Interoperability in Regional Open Access Networks";
@@ -54,6 +90,10 @@ class ChunkingServiceTest {
     }
   }
 
+  /**
+   * Verifies that overlap between consecutive fragments respects the configured
+   * overlap upper bound.
+   */
   @Test
   void shouldRespectConfiguredOverlapBoundaryBetweenConsecutiveChunks() {
     String title = "Cross-Repository Semantic Similarity";
@@ -79,6 +119,10 @@ class ChunkingServiceTest {
     }
   }
 
+  /**
+   * Verifies that chunk generation is capped by the configured maximum chunk
+   * count.
+   */
   @Test
   void shouldRespectConfiguredMaxChunksLimit() {
     ChunkingService limitedChunkingService = new ChunkingService(TEST_MAX_CHUNK_SIZE, TEST_MAX_OVERLAP_SIZE, 2);
@@ -89,6 +133,9 @@ class ChunkingServiceTest {
     assertTrue(chunks.size() <= 2, "Expected chunk count to be capped by configured max chunks");
   }
 
+  /**
+   * Verifies null and blank values for title/abstract return an empty result.
+   */
   @Test
   void shouldHandleNullOrBlankInputsGracefully() {
     assertTrue(chunkingService.chunkTitleAndAbstract(null, "valid").isEmpty());
@@ -97,11 +144,24 @@ class ChunkingServiceTest {
     assertTrue(chunkingService.chunkTitleAndAbstract("valid", " \n\t ").isEmpty());
   }
 
+  /**
+   * Extracts the fragment part from a formatted chunk.
+   *
+   * @param chunk chunk in title + newline + fragment format
+   * @return fragment text after the first newline
+   */
   private static String extractFragment(String chunk) {
     int index = chunk.indexOf('\n');
     return chunk.substring(index + 1);
   }
 
+  /**
+   * Tokenizes text using whitespace and strips non-alphanumeric separators from
+   * each token.
+   *
+   * @param text source text
+   * @return normalized token list used for overlap checks
+   */
   private static List<String> words(String text) {
     return Arrays.stream(WORD_PATTERN.split(text.trim()))
         .filter(token -> !token.isBlank())
@@ -110,6 +170,13 @@ class ChunkingServiceTest {
         .toList();
   }
 
+  /**
+   * Builds a synthetic multi-sentence abstract for chunking tests.
+   *
+   * @param sentenceCount    number of sentences to generate
+   * @param wordsPerSentence number of numbered tokens to inject per sentence
+   * @return generated abstract text
+   */
   private static String buildLongAbstract(int sentenceCount, int wordsPerSentence) {
     StringBuilder sb = new StringBuilder();
 
@@ -130,6 +197,12 @@ class ChunkingServiceTest {
     return sb.toString();
   }
 
+  /**
+   * Builds a single long sentence with numbered tokens.
+   *
+   * @param words number of tokens to generate
+   * @return generated sentence ending with a period
+   */
   private static String buildSingleSentenceAbstract(int words) {
     StringBuilder sb = new StringBuilder();
     for (int i = 1; i <= words; i++) {


### PR DESCRIPTION
This PR updates the embedding generation pipeline to improve semantic search quality and control embedding generation for large abstracts.

Previously, embeddings were generated using the full title and full abstract as a single text input.

With this change, embeddings are now generated using:

* `title`
* `title + chunk1`
* `title + chunk2`
* `title + chunk3`

Each abstract chunk is embedded independently while preserving the document context through the title prefix.

### Changes

* Added abstract chunking before embedding generation
* Generated a standalone embedding for the document title
* Generated embeddings for each abstract chunk independently
* Prefixed every abstract chunk with the document title
* Added a configuration variable to limit the maximum number of abstract chunks used for embedding generation
* Improved preprocessing for large abstracts

### Motivation

Using title-prefixed chunks improves semantic context during retrieval while avoiding excessively large embedding generation workloads.

This approach provides:

* Better contextual relevance for each chunk
* Improved semantic search accuracy
* More granular retrieval results
* Reduced information dilution in long abstracts
* Better control over processing and storage costs for extremely large abstracts

### Configuration

Added new embedding chunking configurations:

```properties
# The maximum size of a segment, defined in tokens.
embedding.max.segment.size.tokens=128

# The maximum overlap size between segments, defined in tokens.
embedding.max.overlap.size.tokens=0

# The maximum number of chunks to generate for a document abstract.
# If the abstract is too large, it will be truncated to fit within this limit.
embedding.max.chunks.size=5
```

If an abstract exceeds the configured limit, remaining chunks are ignored.
